### PR TITLE
Added to build-tools category

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -1,6 +1,7 @@
 {
   "name": "coffee-script-precompiler",
   "version": "0.0.3",
+  "categories": ["build-tools"],
   "description": "compiles coffeescript to javascript on each push",
   "dependencies": {
     "couchtypes": null,


### PR DESCRIPTION
http://kan.so/packages now supports categories for packages. After updating kanso.json with the categories you will need to re-publish. Use "kanso publish -f" to overwrite the current version.
