### PR TITLE
Removed unnecessary dependencies

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -4,9 +4,7 @@
     "categories": ["build-tools"],
     "description": "Compiles CoffeeScript modules and attachments to javascript on each push",
     "dependencies": {
-        "couchtypes": null,
         "modules": null,
-        "settings": null,
         "coffee-script": null
     },
     "preprocessors": {


### PR DESCRIPTION
I have removed a couple of dependencies from this package as they don't appear to be needed.
The couchtypes dependency, in particular, pulls in loads of other packages.
Sometimes the client may want to keep things simple.

(By the way, I noticed that the coffeescript package includes all the documentation and examples, which then get pushed to the design document.  This seems a bit heavy handed - is there some way of preventing this, maybe removing them from the package or using a modules_attachments: false setting?

Cheers,
Pete
