### PR TITLE
Problem with attachments

### DIFF
--- a/src/compile.coffee
+++ b/src/compile.coffee
@@ -51,7 +51,7 @@ compile_attachment = (doc, path, filename, callback) ->
   name = utils.relpath(filename, path).replace(/\.coffee$/, ".js")
   compile_coffee path, filename, (err, js) ->
     return callback(err)  if err
-    attachments.add(doc, name, name, js.toString()
+    attachments.add doc, name, name, js.toString()
     callback()
 
 compile_coffee = (project_path, filename, callback) ->


### PR DESCRIPTION
Hi,
I was getting a problem when trying to attach files compile from coffeescript.  It appeared that the doc_attachments object had not been created so it was blowing up. I have changed the code to use the kanso-utils/attachments utility to "add" the attachment instead.
Let me know what you think.
Pete
